### PR TITLE
support python3

### DIFF
--- a/tdlog/logger.py
+++ b/tdlog/logger.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import logging
 import os
 import sys, urllib
@@ -5,6 +7,10 @@ import msgpack
 import socket
 import threading
 import json
+
+if sys.version > '2':
+    long = int
+
 
 class TreasureDataLogRecordFormatter:
     def __init__(self):
@@ -102,7 +108,7 @@ class TreasureDataHandler(logging.Handler):
         tag = "td.%s.%s" % (self.db, self.table)
         packet = [ tag, time, data ]
         if self.verbose:
-            print packet
+            print(packet)
         return msgpack.packb(packet)
 
     def _send(self, bytes):


### PR DESCRIPTION
This PR supports python3.

I just tested manually the following code in CLI by Python 3.4.3 and 2.7.6 in Mac 10.10.4.

```
import logging
from tdlog import logger

logging.basicConfig(level=logging.INFO)
l = logging.getLogger('td_logger.test')
l.addHandler(logger.TreasureDataHandler())

l.info('Some message')
js = { "semicolon" : ";", "at" : "@" }
l.info(js)
```

Is there any official test for this module?
Where is `run_tests.py`? Please give me a reference. I am happy to test this.

```
$ sudo easy_install virtualenv
$ virtualenv --no-site-packages .     
New python executable in ./bin/python
Installing setuptools............done.
Installing pip...............done.
$ source bin/activate
$ bin/pip install msgpack-python
$ python run_tests.py
```