### PR TITLE
fixed plain text message delivery 

### DIFF
--- a/tdlog/logger.py
+++ b/tdlog/logger.py
@@ -32,9 +32,9 @@ class TreasureDataLogRecordFormatter:
             self._add_dic(data, msg)
         elif isinstance(msg, str):
             try:
-                self.add_dic(data, json.loads(str(msg)))
-            except:
-                pass
+                self._add_dic(data, json.loads(str(msg)))
+            except ValueError:
+                self._add_dic(data, { 'msg' : str(msg) })
 
     def _add_dic(self, data, dic):
         for k, v in dic.items():


### PR DESCRIPTION
there were trouble with code like 
>
> import logging
> from tdlog import logger
> logging.basicConfig(level=logging.INFO)
> l = logging.getLogger('td.debug.test')
> l.addHandler(logger.TreasureDataHandler())
> l.info('Some message')
>

the message 'Some message' was not delivered as specified in readme document